### PR TITLE
Replace React createElement Function Call with JSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+# Created by .ignore support plugin (hsz.mobi)

--- a/execises/02-jsx.html
+++ b/execises/02-jsx.html
@@ -1,0 +1,19 @@
+<div id="root"></div>
+<script src="https://unpkg.com/react@16.0.0-rc.3/umd/react.production.min.js"></script>
+<script src="https://unpkg.com/react-dom@16.0.0-rc.3/umd/react-dom.production.min.js"></script>
+<script src="https://unpkg.com/babel-standalone@6.26.0/babel.js"></script>
+<script type="text/babel">
+  const rootElement = document.getElementById('root');
+  // const element = React.createElement('div', {
+  //   className: 'container',
+  //   children: 'Hello World',
+  // });
+  const content = 'Hello World';
+  const myClassName = 'container';
+  const props = {
+    className: 'container',
+    children: 'Hello World',
+  };
+  const element = <div {...props} />
+  ReactDOM.render(element, rootElement)
+</script>


### PR DESCRIPTION
In this lesson, we'll learn what JSX is and how it can replace calls to React's createElement API. We will go over how you can interop regular Javascript right in the JSX with curly brackets. We will learn how to pass props to JSX and how to override and props that get passed in. In addition to the noted className difference, there are [a number of other differences](https://facebook.github.io/react/docs/dom-elements.html) with attributes in JSX than those in HTML.